### PR TITLE
upstart configuration

### DIFF
--- a/graphios.conf
+++ b/graphios.conf
@@ -1,0 +1,7 @@
+description "Graphios"
+author  "author"
+
+start on runlevel [234]
+stop on runlevel [016]
+
+exec /opt/nagios/bin/graphios.py


### PR DESCRIPTION
[Upstart](http://upstart.ubuntu.com/) configuration file, tested on Ubuntu 10.04 & 12.04

copy `graphios.conf` to `/etc/init/`

Reload the configuration files
`$ initctl reload-configuration`

Start it:
`$ start graphios`

To stop it 
`$ stop graphios`
