### PR TITLE
added exception for incomplete metrics

### DIFF
--- a/graphios.py
+++ b/graphios.py
@@ -347,7 +347,13 @@ def get_mobj(nag_array):
     """
     mobj = GraphiosMetric()
     for var in nag_array:
-        (var_name, value) = var.split('::', 1)
+        # drop the metric if we can't split it for any reason
+        try:
+            (var_name, value) = var.split('::', 1)
+        except:
+            log.warn("could not split value %s, dropping metric" % var)
+            return False
+
         value = re.sub("/", cfg["replacement_character"], value)
         if re.search("PERFDATA", var_name):
             mobj.PERFDATA = value


### PR DESCRIPTION
@shawn-sterling 

Hi there, first off, thanks for the awesome software.  =D

So we run into some problem where graphios throws an exception and crashes every couple of days or so.  The stack trace is below.  Looks like every so often, we get some malformed perfdata where the host object has no trailing ::HOSTNAME.

We're running a distributed icinga 1.11 connected via nsca-ng.  I have no idea if that's useful info or not.  =)

At any rate, for us, it's better to just drop the data and move on, so I put in the below workaround.  Not sure if you wanted this or not but I figured I'd share.

Thanks again for the awesome work!

```
jason@laptop ~/Downloads/pyhook-2014-12-08-15:37:47-2696
>cat backtrace 
graphios.py:311:get_mobj:ValueError: need more than 1 value to unpack

Traceback (most recent call last):
  File "/usr/bin/graphios.py", line 474, in <module>
    main()
  File "/usr/bin/graphios.py", line 453, in main
    process_spool_dir(spool_directory)
  File "/usr/bin/graphios.py", line 358, in process_spool_dir
    mobjs = process_log(file_dir)
  File "/usr/bin/graphios.py", line 285, in process_log
    mobj = get_mobj(variables)
  File "/usr/bin/graphios.py", line 311, in get_mobj
    (var_name, value) = var.split('::', 1)
ValueError: need more than 1 value to unpack

Local variables in innermost frame:
var: 'HOST'
mobj: <__main__.GraphiosMetric object at 0xef8590>
var_name: 'TIMET'
nag_array: ['DATATYPE::SERVICEPERFDATA', 'TIMET::1418074663', 'HOST']
value: '1418074663'
jason@laptop ~/Downloads/pyhook-2014-12-08-15:37:47-2696
>cat reason
graphios.py:311:get_mobj:ValueError: need more than 1 value to unpack
```
