### PR TITLE
Ensure carbon_max_metrics, log_max_size and influxdb_max_metrics are int...

### DIFF
--- a/graphios.py
+++ b/graphios.py
@@ -296,6 +296,12 @@ def configure():
     sets up graphios config
     """
     global debug
+    try:
+        cfg["log_max_size"] = int(cfg["log_max_size"])
+    except ValueError:
+        print "log_max_size needs to be a integer"
+        sys.exit(1)
+
     log_handler = logging.handlers.RotatingFileHandler(
         cfg["log_file"], maxBytes=cfg["log_max_size"], backupCount=4,
         # encoding='bz2')

--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -245,6 +245,12 @@ class carbon(object):
             self.carbon_max_metrics = 200
 
         try:
+            self.carbon_max_metrics = int(self.carbon_max_metrics)
+        except ValueError:
+            self.log.critical("carbon_max_metrics needs to be a integer")
+            sys.exit(1)
+
+        try:
             cfg['use_service_desc']
             self.use_service_desc = cfg['use_service_desc']
         except:
@@ -493,6 +499,12 @@ class influxdb(object):
             self.influxdb_max_metrics = cfg['influxdb_max_metrics']
         else:
             self.influxdb_max_metrics = 250
+
+        try:
+            self.influxdb_max_metrics = int(self.influxdb_max_metrics)
+        except ValueError:
+            self.log.critical("influxdb_max_metrics needs to be a integer")
+            sys.exit(1)
 
     def build_url(self, server):
         """ Returns a url to specified InfluxDB-server """


### PR DESCRIPTION
Values parsed from graphios.cfg defaults to strings, this (silently) breaks the log rotation and (not so silently) breaks chunks() if carbon_max_metrics or influxdb_max_metrics are set in graphios.cfg so here's a pull request that ensure that those are ints.

On a side note, specifying log_max_size in bytes in graphios.cfg feels a bit awkward. Maybe it should be in megabytes in graphios.cfg and then we convert it to bytes before setting up the log rotation?