### PR TITLE
Add the ability to use InfluxDB 0.9

### DIFF
--- a/graphios.cfg
+++ b/graphios.cfg
@@ -10,10 +10,10 @@
 replacement_character = _
 
 # nagios spool directory
-spool_directory = /var/spool/nagios/graphios
+spool_directory = /var/spool/graphios/
 
 # graphios log info
-log_file = /usr/local/nagios/var/graphios.log
+log_file = /var/log/nagios/graphios.log
 
 # max log size (it will rotate the files) default: 24 MB
 log_max_size = 25165824
@@ -111,7 +111,7 @@ librato_whitelist = [".*"]
 #nerf_librato = False
 
 #------------------------------------------------------------------------------
-# InfluxDB Details (comment in if you are using InfluxDB)
+# InfluxDB Details (comment in if you are using InfluxDB 0.8)
 #------------------------------------------------------------------------------
 
 enable_influxdb = False
@@ -132,6 +132,38 @@ enable_influxdb = False
 
 # Max metrics to send / request, defaults to 250
 #influxdb_max_metrics = 500
+
+# Flag the InfluxDB backend as 'non essential' for the purposes of error checking
+#nerf_influxdb = False
+
+#------------------------------------------------------------------------------
+# InfluxDB Details (uncomment if you are using InfluxDB 0.9)
+# This will work a bit differently because of the addition of tags in 
+# InfluxDB 0.9.  Now the metric will be named after the perfdata field, 
+# the check name will be a tag, and the host name will be a tag.  The value of
+# the metric is stored in the 'value' column.
+#------------------------------------------------------------------------------
+
+enable_influxdb09 = True
+
+# Comma separated list of server:ports
+# defaults to 127.0.0.1:8086 (:8087 if using SSL).
+
+# SSL, defaults to False
+#influxdb_use_ssl = True
+
+# Database-name, defaults to nagios
+#influxdb_db = <your influxdb-database>
+
+# Credentials (required)
+influxdb_user = root
+influxdb_password = root
+
+# Max metrics to send / request, defaults to 250
+#influxdb_max_metrics = 20000
+
+# Extra tags to add to metrics, like data center location etc.
+#influxdb_extra_tags = {"location": "la"}
 
 # Flag the InfluxDB backend as 'non essential' for the purposes of error checking
 #nerf_influxdb = False

--- a/graphios.cfg
+++ b/graphios.cfg
@@ -139,8 +139,8 @@ enable_influxdb = False
 #------------------------------------------------------------------------------
 # InfluxDB Details (uncomment if you are using InfluxDB 0.9)
 # This will work a bit differently because of the addition of tags in 
-# InfluxDB 0.9.  Now the metric will be named after the perfdata field, 
-# the check name will be a tag, and the host name will be a tag.  The value of
+# InfluxDB 0.9.  Now the metric will be named after the service description,
+# the perfdata field will be a tag, and the host name will be a tag.  The value of
 # the metric is stored in the 'value' column.
 #------------------------------------------------------------------------------
 
@@ -160,10 +160,10 @@ influxdb_user = root
 influxdb_password = root
 
 # Max metrics to send / request, defaults to 250
-#influxdb_max_metrics = 20000
+influxdb_max_metrics = 20000
 
 # Extra tags to add to metrics, like data center location etc.
-#influxdb_extra_tags = {"location": "la"}
+influxdb_extra_tags = {"location": "la"}
 
 # Flag the InfluxDB backend as 'non essential' for the purposes of error checking
 #nerf_influxdb = False

--- a/graphios.py
+++ b/graphios.py
@@ -487,6 +487,7 @@ def init_backends():
                       "statsd",
                       "librato",
                       "influxdb",
+                      "influxdb09",
                       "stdout",
                       )
     # populate the controller dict from avail + config. this assumes you named


### PR DESCRIPTION
This is a proof of concept for using tags introduced in version InfluxDB 0.9 
rather than the traditional dot notation used in graphite.

This no longer uses the dot notation for metric names, but instead uses
tags to specify the metadata. The service description is used as the
metric name, and the value is stored in a column named 'value'.  Both
the host name and perfdata variable name are stored as tags. An admin also
has the ability to specify additional tags like data center location
etc.

This corrects the last commit, which mistakenly mixed up what went in
the name and what went in tags when describing how it worked.