### PR TITLE
Add the ability to use InfluxDB 0.9

### DIFF
--- a/graphios.cfg
+++ b/graphios.cfg
@@ -10,10 +10,10 @@
 replacement_character = _
 
 # nagios spool directory
-spool_directory = /var/spool/nagios/graphios
+spool_directory = /var/spool/graphios/
 
 # graphios log info
-log_file = /usr/local/nagios/var/graphios.log
+log_file = /var/log/nagios/graphios.log
 
 # max log size (it will rotate the files) default: 24 MB
 log_max_size = 25165824
@@ -111,7 +111,7 @@ librato_whitelist = [".*"]
 #nerf_librato = False
 
 #------------------------------------------------------------------------------
-# InfluxDB Details (comment in if you are using InfluxDB)
+# InfluxDB Details (comment in if you are using InfluxDB 0.8)
 #------------------------------------------------------------------------------
 
 enable_influxdb = False
@@ -132,6 +132,38 @@ enable_influxdb = False
 
 # Max metrics to send / request, defaults to 250
 #influxdb_max_metrics = 500
+
+# Flag the InfluxDB backend as 'non essential' for the purposes of error checking
+#nerf_influxdb = False
+
+#------------------------------------------------------------------------------
+# InfluxDB Details (uncomment if you are using InfluxDB 0.9)
+# This will work a bit differently because of the addition of tags in 
+# InfluxDB 0.9.  Now the metric will be named after the perfdata field, 
+# the check name will be a tag, and the host name will be a tag.  The value of
+# the metric is stored in the 'value' column.
+#------------------------------------------------------------------------------
+
+enable_influxdb09 = True
+
+# Comma separated list of server:ports
+# defaults to 127.0.0.1:8086 (:8087 if using SSL).
+
+# SSL, defaults to False
+#influxdb_use_ssl = True
+
+# Database-name, defaults to nagios
+#influxdb_db = <your influxdb-database>
+
+# Credentials (required)
+influxdb_user = root
+influxdb_password = root
+
+# Max metrics to send / request, defaults to 250
+#influxdb_max_metrics = 20000
+
+# Extra tags to add to metrics, like data center location etc.
+#influxdb_extra_tags = {"location": "la"}
 
 # Flag the InfluxDB backend as 'non essential' for the purposes of error checking
 #nerf_influxdb = False

--- a/graphios.cfg
+++ b/graphios.cfg
@@ -139,8 +139,8 @@ enable_influxdb = False
 #------------------------------------------------------------------------------
 # InfluxDB Details (uncomment if you are using InfluxDB 0.9)
 # This will work a bit differently because of the addition of tags in 
-# InfluxDB 0.9.  Now the metric will be named after the perfdata field, 
-# the check name will be a tag, and the host name will be a tag.  The value of
+# InfluxDB 0.9.  Now the metric will be named after the service description,
+# the perfdata field will be a tag, and the host name will be a tag.  The value of
 # the metric is stored in the 'value' column.
 #------------------------------------------------------------------------------
 
@@ -160,10 +160,10 @@ influxdb_user = root
 influxdb_password = root
 
 # Max metrics to send / request, defaults to 250
-#influxdb_max_metrics = 20000
+influxdb_max_metrics = 20000
 
 # Extra tags to add to metrics, like data center location etc.
-#influxdb_extra_tags = {"location": "la"}
+influxdb_extra_tags = {"location": "la"}
 
 # Flag the InfluxDB backend as 'non essential' for the purposes of error checking
 #nerf_influxdb = False

--- a/graphios.cfg
+++ b/graphios.cfg
@@ -36,7 +36,7 @@ sleep_max = 480
 test_mode = False
 
 # use service description, most people will NOT want this, read documentation!
-use_service_desc = False
+use_service_desc = True
 
 # replace "." in nagios hostnames? (so "my.host.name" becomes "my_host_name")
 # (uses the replacement_character)
@@ -140,14 +140,16 @@ enable_influxdb = False
 # InfluxDB Details (uncomment if you are using InfluxDB 0.9)
 # This will work a bit differently because of the addition of tags in 
 # InfluxDB 0.9.  Now the metric will be named after the service description,
-# the perfdata field will be a tag, and the host name will be a tag.  The value of
-# the metric is stored in the 'value' column.
+# the perfdata field will be a tag, and the host name will be a tag.  The value
+# of the metric is stored in the 'value' column. 
+# Requires use_service_desc = True.
 #------------------------------------------------------------------------------
 
 enable_influxdb09 = True
 
 # Comma separated list of server:ports
 # defaults to 127.0.0.1:8086 (:8087 if using SSL).
+#influxdb_servers = localhost:8086
 
 # SSL, defaults to False
 #influxdb_use_ssl = True

--- a/graphios.cfg
+++ b/graphios.cfg
@@ -10,10 +10,10 @@
 replacement_character = _
 
 # nagios spool directory
-spool_directory = /var/spool/graphios/
+spool_directory = /var/spool/nagios/graphios
 
 # graphios log info
-log_file = /var/log/nagios/graphios.log
+log_file = /usr/local/nagios/var/graphios.log
 
 # max log size (it will rotate the files) default: 24 MB
 log_max_size = 25165824
@@ -36,7 +36,7 @@ sleep_max = 480
 test_mode = False
 
 # use service description, most people will NOT want this, read documentation!
-use_service_desc = True
+use_service_desc = False
 
 # replace "." in nagios hostnames? (so "my.host.name" becomes "my_host_name")
 # (uses the replacement_character)
@@ -111,10 +111,25 @@ librato_whitelist = [".*"]
 #nerf_librato = False
 
 #------------------------------------------------------------------------------
-# InfluxDB Details (comment in if you are using InfluxDB 0.8)
+# InfluxDB Details (if you are using InfluxDB 0.8)
 #------------------------------------------------------------------------------
 
 enable_influxdb = False
+
+#------------------------------------------------------------------------------
+# InfluxDB Details (if you are using InfluxDB 0.9)
+# This will work a bit differently because of the addition of tags in 
+# InfluxDB 0.9.  Now the metric will be named after the service description,
+# the perfdata field will be a tag, and the host name will be a tag.  The value
+# of the metric is stored in the 'value' column. 
+# Requires use_service_desc = True.
+#------------------------------------------------------------------------------
+
+enable_influxdb09 = False
+
+# Extra tags to add to metrics, like data center location etc.
+# Only valid for 0.9
+#influxdb_extra_tags = {"location": "la"}
 
 # Comma separated list of server:ports
 # defaults to 127.0.0.1:8086 (:8087 if using SSL).
@@ -136,39 +151,6 @@ enable_influxdb = False
 # Flag the InfluxDB backend as 'non essential' for the purposes of error checking
 #nerf_influxdb = False
 
-#------------------------------------------------------------------------------
-# InfluxDB Details (uncomment if you are using InfluxDB 0.9)
-# This will work a bit differently because of the addition of tags in 
-# InfluxDB 0.9.  Now the metric will be named after the service description,
-# the perfdata field will be a tag, and the host name will be a tag.  The value
-# of the metric is stored in the 'value' column. 
-# Requires use_service_desc = True.
-#------------------------------------------------------------------------------
-
-enable_influxdb09 = True
-
-# Comma separated list of server:ports
-# defaults to 127.0.0.1:8086 (:8087 if using SSL).
-#influxdb_servers = localhost:8086
-
-# SSL, defaults to False
-#influxdb_use_ssl = True
-
-# Database-name, defaults to nagios
-#influxdb_db = <your influxdb-database>
-
-# Credentials (required)
-influxdb_user = root
-influxdb_password = root
-
-# Max metrics to send / request, defaults to 250
-influxdb_max_metrics = 20000
-
-# Extra tags to add to metrics, like data center location etc.
-influxdb_extra_tags = {"location": "la"}
-
-# Flag the InfluxDB backend as 'non essential' for the purposes of error checking
-#nerf_influxdb = False
 
 #------------------------------------------------------------------------------
 # STDOUT Details (comment in if you are using STDOUT)

--- a/graphios.py
+++ b/graphios.py
@@ -487,6 +487,7 @@ def init_backends():
                       "statsd",
                       "librato",
                       "influxdb",
+                      "influxdb09",
                       "stdout",
                       )
     # populate the controller dict from avail + config. this assumes you named

--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -457,6 +457,7 @@ class statsd(object):
 
         return ret
 
+
 # ###########################################################
 # #### influxdb backend  ####################################
 
@@ -600,7 +601,6 @@ class influxdb(object):
         return ret
 
 
-
 # ###########################################################
 # #### influxdb-0.9 backend  ####################################
 
@@ -645,7 +645,8 @@ class influxdb09(object):
             self.influxdb_max_metrics = 250
 
         if 'influxdb_extra_tags' in cfg:
-            self.influxdb_extra_tags = ast.literal_eval(cfg['influxdb_extra_tags'])
+            self.influxdb_extra_tags = ast.literal_eval(
+                cfg['influxdb_extra_tags'])
             print self.influxdb_extra_tags
         else:
             self.influxdb_extra_tags = {}
@@ -663,8 +664,8 @@ class influxdb09(object):
             server = "%s:%i" % (server, self.default_ports[self.scheme])
 
         return "%s://%s/write?u=%s&p=%s" % (self.scheme, server,
-                                                   self.influxdb_user,
-                                                   self.influxdb_password)
+                                            self.influxdb_user,
+                                            self.influxdb_password)
 
     def chunks(self, l, n):
         """ Yield successive n-sized chunks from l. """
@@ -672,7 +673,6 @@ class influxdb09(object):
             yield l[i:i+n]
 
     def send(self, metrics):
-        from pprint import pprint
         """ Connect to influxdb and send metrics """
         ret = 0
         perfdata = []
@@ -693,16 +693,14 @@ class influxdb09(object):
                 except ValueError:
                     value = 0
 
-            tags = { "check": m.LABEL, "host": m.HOSTNAME }
+            tags = {"check": m.LABEL, "host": m.HOSTNAME}
             tags.update(self.influxdb_extra_tags)
 
             perfdata.append({
-                                "timestamp": int(m.TIMET),
-                                "name": path,
-                                "tags": tags,
-                                "fields": {"value": value}
-                            })
-
+                            "timestamp": int(m.TIMET),
+                            "name": path,
+                            "tags": tags,
+                            "fields": {"value": value}})
 
         series_chunks = self.chunks(perfdata, self.influxdb_max_metrics)
         for chunk in series_chunks:
@@ -714,9 +712,8 @@ class influxdb09(object):
                 req.add_header('Content-Type', 'application/json')
 
                 try:
-                    pass
-                    #r = urllib2.urlopen(req, timeout=self.timeout)
-                    #r.close()
+                    r = urllib2.urlopen(req, timeout=self.timeout)
+                    r.close()
                 except urllib2.HTTPError as e:
                     ret = 0
                     body = e.read()

--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -542,6 +542,30 @@ class influxdb(object):
         for i in xrange(0, len(l), n):
             yield l[i:i+n]
 
+    def _send(self, server, chunk):
+        self.log.debug("Connecting to InfluxDB at %s" % server)
+        json_body = json.dumps(chunk)
+        req = urllib2.Request(self.build_url(server), json_body)
+        req.add_header('Content-Type', 'application/json')
+
+        try:
+            r = urllib2.urlopen(req, timeout=self.timeout)
+            r.close()
+            return True
+        except urllib2.HTTPError as e:
+            body = e.read()
+            self.log.warning('Failed to send metrics to InfluxDB. \
+                                Status code: %d: %s' % (e.code, body))
+            return False
+        except IOError as e:
+            fail_string = "Failed to send metrics to InfluxDB. "
+            if hasattr(e, 'code'):
+                fail_string = fail_string + "Status code: %s" % e.code
+            if hasattr(e, 'reason'):
+                fail_string = fail_string + str(e.reason)
+            self.log.warning(fail_string)
+            return False
+
     def send(self, metrics):
         """ Connect to influxdb and send metrics """
         ret = 0
@@ -576,27 +600,8 @@ class influxdb(object):
         series_chunks = self.chunks(series, self.influxdb_max_metrics)
         for chunk in series_chunks:
             for s in self.influxdb_servers:
-                self.log.debug("Connecting to InfluxDB at %s" % s)
-                json_body = json.dumps(chunk)
-                req = urllib2.Request(self.build_url(s), json_body)
-                req.add_header('Content-Type', 'application/json')
-
-                try:
-                    r = urllib2.urlopen(req, timeout=self.timeout)
-                    r.close()
-                except urllib2.HTTPError as e:
+                if not self._send(s, chunk):
                     ret = 0
-                    body = e.read()
-                    self.log.warning('Failed to send metrics to InfluxDB. \
-                                        Status code: %d: %s' % (e.code, body))
-                except IOError as e:
-                    ret = 0
-                    fail_string = "Failed to send metrics to InfluxDB. "
-                    if hasattr(e, 'code'):
-                        fail_string = fail_string + "Status code: %s" % e.code
-                    if hasattr(e, 'reason'):
-                        fail_string = fail_string + str(e.reason)
-                    self.log.warning(fail_string)
 
         return ret
 
@@ -604,58 +609,15 @@ class influxdb(object):
 # ###########################################################
 # #### influxdb-0.9 backend  ####################################
 
-class influxdb09(object):
+class influxdb09(influxdb):
     def __init__(self, cfg):
-        self.log = logging.getLogger("log.backends.influxdb")
-        self.log.info("InfluxDB backend initialized")
-        self.scheme = "http"
-        self.default_ports = {'https': 8087, 'http': 8086}
-        self.timeout = 5
-
-        if 'influxdb_use_ssl' in cfg:
-            if cfg['influxdb_use_ssl']:
-                self.scheme = "https"
-
-        if 'influxdb_servers' in cfg:
-            self.influxdb_servers = cfg['influxdb_servers'].split(',')
-        else:
-            self.influxdb_servers = ['127.0.0.1:%i' %
-                                     self.default_ports[self.scheme]]
-
-        if 'influxdb_user' in cfg:
-            self.influxdb_user = cfg['influxdb_user']
-        else:
-            self.log.critical("Missing influxdb_user in graphios.cfg")
-            sys.exit(1)
-
-        if 'influxdb_password' in cfg:
-            self.influxdb_password = cfg['influxdb_password']
-        else:
-            self.log.critical("Missing influxdb_password in graphios.cfg")
-            sys.exit(1)
-
-        if 'influxdb_db' in cfg:
-            self.influxdb_db = cfg['influxdb_db']
-        else:
-            self.influxdb_db = "nagios"
-
-        if 'influxdb_max_metrics' in cfg:
-            self.influxdb_max_metrics = cfg['influxdb_max_metrics']
-        else:
-            self.influxdb_max_metrics = 250
-
+        influxdb.__init__(self, cfg)
         if 'influxdb_extra_tags' in cfg:
             self.influxdb_extra_tags = ast.literal_eval(
                 cfg['influxdb_extra_tags'])
             print self.influxdb_extra_tags
         else:
             self.influxdb_extra_tags = {}
-
-        try:
-            self.influxdb_max_metrics = int(self.influxdb_max_metrics)
-        except ValueError:
-            self.log.critical("influxdb_max_metrics needs to be a integer")
-            sys.exit(1)
 
     def build_url(self, server):
         """ Returns a url to specified InfluxDB-server """
@@ -666,11 +628,6 @@ class influxdb09(object):
         return "%s://%s/write?u=%s&p=%s" % (self.scheme, server,
                                             self.influxdb_user,
                                             self.influxdb_password)
-
-    def chunks(self, l, n):
-        """ Yield successive n-sized chunks from l. """
-        for i in xrange(0, len(l), n):
-            yield l[i:i+n]
 
     def send(self, metrics):
         """ Connect to influxdb and send metrics """
@@ -706,27 +663,8 @@ class influxdb09(object):
         for chunk in series_chunks:
             series = {"database": self.influxdb_db, "points": chunk}
             for s in self.influxdb_servers:
-                self.log.debug("Connecting to InfluxDB at %s" % s)
-                json_body = json.dumps(series)
-                req = urllib2.Request(self.build_url(s), json_body)
-                req.add_header('Content-Type', 'application/json')
-
-                try:
-                    r = urllib2.urlopen(req, timeout=self.timeout)
-                    r.close()
-                except urllib2.HTTPError as e:
+                if not self._send(s, series):
                     ret = 0
-                    body = e.read()
-                    self.log.warning('Failed to send metrics to InfluxDB. \
-                                        Status code: %d: %s' % (e.code, body))
-                except IOError as e:
-                    ret = 0
-                    fail_string = "Failed to send metrics to InfluxDB. "
-                    if hasattr(e, 'code'):
-                        fail_string = fail_string + "Status code: %s" % e.code
-                    if hasattr(e, 'reason'):
-                        fail_string = fail_string + str(e.reason)
-                    self.log.warning(fail_string)
 
         return ret
 


### PR DESCRIPTION
Ok, third try with this will hopefully be the charm.  This is a proof of concept.

This no longer uses the dot notation for metric names, but instead uses
tags to specify the metadata. The service description is used as the
metric name, and the value is stored in a column named 'value'.  Both
the host name and perfdata variable name are stored as tags. An admin also
has the ability to specify additional tags like data center location
etc.