### PR TITLE
Added a metric_base_path setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ You should think carefully about how you name your metrics, because later on,
 these names will enable you to easily combine metrics (like load1) across
 various sources (like all webservers).
 
+Using metric_base_path to add a universal prefix
+------------------------------------------------
+
+In an environment where multiple things are feeding metrics into your backend
+service, it can be handy to differentiate by source. Normally, you would need
+to prepend the graphiteprefix to all services and hosts, but in some cases, this
+isn't possible or feasible. 
+
+When you want everything to be prepended with the same string, use the
+metric_base_path setting: 
+
+	metric_base_path	= mycorp.nagios
+	
+Note that quotes will be preserved. Also, _graphiteprefix and _graphitepostfix 
+will be applied in addition to this string, so if you are already adding 
+mycorp.nagios to your prefix, you will end up with mycorp.nagios.mycorp.nagios.metricname
+
 A few words on Naming things for Librato
 ----------------------------------------
 

--- a/graphios.cfg
+++ b/graphios.cfg
@@ -49,6 +49,10 @@ replace_hostname = True
 # tld.company.datacenter.host
 reverse_hostname = False
 
+# This string will be universally pre-pended to metrics, regardless of whether
+# or not _graphiteprefix is set. 
+# metric_base_path = mycorp.nagios
+
 #------------------------------------------------------------------------------
 # Carbon Details (comment out if not using carbon)
 #------------------------------------------------------------------------------

--- a/graphios.py
+++ b/graphios.py
@@ -130,6 +130,9 @@ class GraphiosMetric(object):
         self.GRAPHITEPOSTFIX = ''       # graphios suffix
         self.VALID = False              # if this metric is valid
 
+        if 'metric_base_path' in cfg:
+            self.METRICBASEPATH = cfg['metric_base_path']
+
     def validate(self):
         # because we eliminated all whitespace, there shouldn't be any quotes
         # this happens more with windows nagios plugins

--- a/graphios.py
+++ b/graphios.py
@@ -110,24 +110,25 @@ log = logging.getLogger('log')
 
 class GraphiosMetric(object):
     def __init__(self):
-        self.LABEL = ''                 # The name in the perfdata from nagios
-        self.VALUE = ''                 # The measured value of that metric
-        self.UOM = ''                   # The unit of measure for the metric
-        self.DATATYPE = ''              # HOSTPERFDATA|SERVICEPERFDATA
-        self.METRICTYPE = 'gauge'       # gauge|counter|timer etc..
-        self.TIMET = ''                 # Epoc time the measurement was taken
-        self.HOSTNAME = ''              # name of th host measured
-        self.SERVICEDESC = ''           # nagios configured service description
-        self.PERFDATA = ''              # the space-delimited raw perfdata
-        self.SERVICECHECKCOMMAND = ''   # literal check command syntax
-        self.HOSTCHECKCOMMAND = ''      # literal check command syntax
-        self.HOSTSTATE = ''             # current state afa nagios is concerned
-        self.HOSTSTATETYPE = ''         # HARD|SOFT
-        self.SERVICESTATE = ''          # current state afa nagios is concerned
-        self.SERVICESTATETYPE = ''      # HARD|SOFT
-        self.GRAPHITEPREFIX = ''        # graphios prefix
-        self.GRAPHITEPOSTFIX = ''       # graphios suffix
-        self.VALID = False              # if this metric is valid
+        self.LABEL = ''                                 # The name in the perfdata from nagios
+        self.VALUE = ''                                 # The measured value of that metric
+        self.UOM = ''                                   # The unit of measure for the metric
+        self.DATATYPE = ''                              # HOSTPERFDATA|SERVICEPERFDATA
+        self.METRICTYPE = 'gauge'                       # gauge|counter|timer etc..
+        self.TIMET = ''                                 # Epoc time the measurement was taken
+        self.HOSTNAME = ''                              # name of th host measured
+        self.SERVICEDESC = ''                           # nagios configured service description
+        self.PERFDATA = ''                              # the space-delimited raw perfdata
+        self.SERVICECHECKCOMMAND = ''                   # literal check command syntax
+        self.HOSTCHECKCOMMAND = ''                      # literal check command syntax
+        self.HOSTSTATE = ''                             # current state afa nagios is concerned
+        self.HOSTSTATETYPE = ''                         # HARD|SOFT
+        self.SERVICESTATE = ''                          # current state afa nagios is concerned
+        self.SERVICESTATETYPE = ''                      # HARD|SOFT
+        self.METRICBASEPATH = cfg["metric_base_path"]   # Establishes a root base path
+        self.GRAPHITEPREFIX = ''                        # graphios prefix
+        self.GRAPHITEPOSTFIX = ''                       # graphios suffix
+        self.VALID = False                              # if this metric is valid
 
     def validate(self):
         # because we eliminated all whitespace, there shouldn't be any quotes
@@ -148,6 +149,9 @@ class GraphiosMetric(object):
             else:
                 # not using service descriptions
                 if (
+                    # We should keep this logic and not check for a
+                    # base path here. Just because there's a base path 
+                    # doesn't mean the metric should be considered valid
                     self.GRAPHITEPREFIX == "" and
                     self.GRAPHITEPOSTFIX == ""
                 ):

--- a/graphios.py
+++ b/graphios.py
@@ -110,25 +110,25 @@ log = logging.getLogger('log')
 
 class GraphiosMetric(object):
     def __init__(self):
-        self.LABEL = ''                                 # The name in the perfdata from nagios
-        self.VALUE = ''                                 # The measured value of that metric
-        self.UOM = ''                                   # The unit of measure for the metric
-        self.DATATYPE = ''                              # HOSTPERFDATA|SERVICEPERFDATA
-        self.METRICTYPE = 'gauge'                       # gauge|counter|timer etc..
-        self.TIMET = ''                                 # Epoc time the measurement was taken
-        self.HOSTNAME = ''                              # name of th host measured
-        self.SERVICEDESC = ''                           # nagios configured service description
-        self.PERFDATA = ''                              # the space-delimited raw perfdata
-        self.SERVICECHECKCOMMAND = ''                   # literal check command syntax
-        self.HOSTCHECKCOMMAND = ''                      # literal check command syntax
-        self.HOSTSTATE = ''                             # current state afa nagios is concerned
-        self.HOSTSTATETYPE = ''                         # HARD|SOFT
-        self.SERVICESTATE = ''                          # current state afa nagios is concerned
-        self.SERVICESTATETYPE = ''                      # HARD|SOFT
-        self.METRICBASEPATH = cfg["metric_base_path"]   # Establishes a root base path
-        self.GRAPHITEPREFIX = ''                        # graphios prefix
-        self.GRAPHITEPOSTFIX = ''                       # graphios suffix
-        self.VALID = False                              # if this metric is valid
+        self.LABEL = ''                 # The name in the perfdata from nagios
+        self.VALUE = ''                 # The measured value of that metric
+        self.UOM = ''                   # The unit of measure for the metric
+        self.DATATYPE = ''              # HOSTPERFDATA|SERVICEPERFDATA
+        self.METRICTYPE = 'gauge'       # gauge|counter|timer etc..
+        self.TIMET = ''                 # Epoc time the measurement was taken
+        self.HOSTNAME = ''              # name of th host measured
+        self.SERVICEDESC = ''           # nagios configured service description
+        self.PERFDATA = ''              # the space-delimited raw perfdata
+        self.SERVICECHECKCOMMAND = ''   # literal check command syntax
+        self.HOSTCHECKCOMMAND = ''      # literal check command syntax
+        self.HOSTSTATE = ''             # current state afa nagios is concerned
+        self.HOSTSTATETYPE = ''         # HARD|SOFT
+        self.SERVICESTATE = ''          # current state afa nagios is concerned
+        self.SERVICESTATETYPE = ''      # HARD|SOFT
+        self.METRICBASEPATH = ''        # Establishes a root base path
+        self.GRAPHITEPREFIX = ''        # graphios prefix
+        self.GRAPHITEPOSTFIX = ''       # graphios suffix
+        self.VALID = False              # if this metric is valid
 
     def validate(self):
         # because we eliminated all whitespace, there shouldn't be any quotes
@@ -150,7 +150,7 @@ class GraphiosMetric(object):
                 # not using service descriptions
                 if (
                     # We should keep this logic and not check for a
-                    # base path here. Just because there's a base path 
+                    # base path here. Just because there's a base path
                     # doesn't mean the metric should be considered valid
                     self.GRAPHITEPREFIX == "" and
                     self.GRAPHITEPOSTFIX == ""

--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -426,8 +426,9 @@ class statsd(object):
         # Converts the metric object list into a list of statsd tuples
         out_list = []
         for m in metrics:
-            path = '%s.%s.%s.%s.%s' % (m.METRICBASEPATH, m.GRAPHITEPREFIX, m.HOSTNAME,
-                                    m.GRAPHITEPOSTFIX, m.LABEL)
+            path = '%s.%s.%s.%s.%s' % (m.METRICBASEPATH, m.GRAPHITEPREFIX,
+                                       m.HOSTNAME, m.GRAPHITEPOSTFIX,
+                                       m.LABEL)
             path = re.sub(r'\.$', '', path)  # fix paths that end in dot
             path = re.sub(r'\.\.', '.', path)  # fix paths with empty values
             mtype = self.set_type(m)  # gauge|counter|timer|set
@@ -533,7 +534,7 @@ class influxdb(object):
 
         if m.GRAPHITEPREFIX != "":
             path += "%s.%s." % m.GRAPHITEPREFIX
-        
+
         path += "%s." % m.HOSTNAME
 
         if m.SERVICEDESC != "":

--- a/graphios_backends.py
+++ b/graphios_backends.py
@@ -51,7 +51,7 @@ class librato(object):
         try:
             cfg['librato_namevals']
         except:
-            self.namevals = ['GRAPHITEPREFIX', 'SERVICEDESC',
+            self.namevals = ['METRICBASEPATH', 'GRAPHITEPREFIX', 'SERVICEDESC',
                              'GRAPHITEPOSTFIX', 'LABEL']
         else:
             self.namevals = cfg['librato_namevals'].split(",")
@@ -258,6 +258,12 @@ class carbon(object):
             self.use_service_desc = False
 
         try:
+            cfg['metric_base_path']
+            self.metric_base_path = cfg['metric_base_path']
+        except:
+            self.metric_base_path = ''
+
+        try:
             cfg['test_mode']
             self.test_mode = cfg['test_mode']
         except:
@@ -313,10 +319,11 @@ class carbon(object):
         """
         Builds a carbon metric
         """
+        pre = ""
+        if m.METRICBASEPATH != "":
+            pre = "%s." % m.METRICBASEPATH
         if m.GRAPHITEPREFIX != "":
-            pre = "%s." % m.GRAPHITEPREFIX
-        else:
-            pre = ""
+            pre += "%s." % m.GRAPHITEPREFIX
         if m.GRAPHITEPOSTFIX != "":
             post = ".%s" % m.GRAPHITEPOSTFIX
         else:
@@ -419,7 +426,7 @@ class statsd(object):
         # Converts the metric object list into a list of statsd tuples
         out_list = []
         for m in metrics:
-            path = '%s.%s.%s.%s' % (m.GRAPHITEPREFIX, m.HOSTNAME,
+            path = '%s.%s.%s.%s.%s' % (m.METRICBASEPATH, m.GRAPHITEPREFIX, m.HOSTNAME,
                                     m.GRAPHITEPOSTFIX, m.LABEL)
             path = re.sub(r'\.$', '', path)  # fix paths that end in dot
             path = re.sub(r'\.\.', '.', path)  # fix paths with empty values
@@ -521,14 +528,16 @@ class influxdb(object):
     def build_path(self, m):
         """ Returns a path """
         path = ""
+        if m.METRICBASEPATH != "":
+            path += "%s." % m.METRICBASEPATH
 
         if m.GRAPHITEPREFIX != "":
-            path = "%s.%s." % (m.GRAPHITEPREFIX, m.HOSTNAME)
-        else:
-            path = "%s." % m.HOSTNAME
+            path += "%s.%s." % m.GRAPHITEPREFIX
+        
+        path += "%s." % m.HOSTNAME
 
         if m.SERVICEDESC != "":
-            path = "%s%s." % (path, m.SERVICEDESC)
+            path += "%s." % m.SERVICEDESC
 
         path = "%s%s" % (path, m.LABEL)
 
@@ -696,6 +705,7 @@ class stdout(object):
             print("%s:%s" % ('HOSTSTATETYPE ', metric.HOSTSTATETYPE))
             print("%s:%s" % ('SERVICESTATE ', metric.SERVICESTATE))
             print("%s:%s" % ('SERVICESTATETYPE ', metric.SERVICESTATETYPE))
+            print("%s:%s" % ('METRICBASEPATH ', metric.METRICBASEPATH))
             print("%s:%s" % ('GRAPHITEPREFIX ', metric.GRAPHITEPREFIX))
             print("%s:%s" % ('GRAPHITEPOSTFIX ', metric.GRAPHITEPOSTFIX))
             print("-------")


### PR DESCRIPTION
I've taken on an environment that is, we shall say, "rich" with nooks and crannies where configs are stuffed, and inheritance is not used in any sane way. The end result is that I can't reasonably place a GRAPHITEPREFIX on every service, so I wanted a way to do it universally. Hence the metric_base_path config option that allows me to say "ALL METRICS SHALL BEGIN WITH THIS PATH". 

It should be good, but please test it and let me know what you think. 

Thanks! 

--Matt
