### PR TITLE
Set max size of logfiles in megabytes instead of bytes

### DIFF
--- a/graphios.cfg
+++ b/graphios.cfg
@@ -15,8 +15,8 @@ spool_directory = /var/spool/nagios/graphios
 # graphios log info
 log_file = /usr/local/nagios/var/graphios.log
 
-# max log size (it will rotate the files) default: 24 MB
-log_max_size = 25165824
+# max log size in megabytes (it will rotate the files)
+log_max_size = 24
 
 # DEBUG is quite verbose
 #log_level = logging.DEBUG
@@ -118,10 +118,10 @@ enable_influxdb = False
 
 #------------------------------------------------------------------------------
 # InfluxDB Details (if you are using InfluxDB 0.9)
-# This will work a bit differently because of the addition of tags in 
+# This will work a bit differently because of the addition of tags in
 # InfluxDB 0.9.  Now the metric will be named after the service description,
 # the perfdata field will be a tag, and the host name will be a tag.  The value
-# of the metric is stored in the 'value' column. 
+# of the metric is stored in the 'value' column.
 # Requires use_service_desc = True.
 #------------------------------------------------------------------------------
 

--- a/graphios.py
+++ b/graphios.py
@@ -55,7 +55,7 @@ spool_directory = '/var/spool/nagios/graphios'
 
 # graphios log info
 log_file = ''
-log_max_size = 25165824         # 24 MB
+log_max_size = 24
 
 # by default we will check the current path for graphios.cfg, if config_file
 # is passed as a command line argument we will use that instead.
@@ -250,7 +250,7 @@ def verify_options(opts):
         cfg["log_file"] = opts.log_file
     if cfg["log_file"] == "''" or cfg["log_file"] == "":
         cfg["log_file"] = "%s/graphios.log" % sys.path[0]
-    cfg["log_max_size"] = 25165824         # 24 MB
+    cfg["log_max_size"] = 24
     if opts.verbose:
         cfg["debug"] = True
         cfg["log_level"] = "logging.DEBUG"
@@ -302,8 +302,15 @@ def configure():
         print "log_max_size needs to be a integer"
         sys.exit(1)
 
+    # Convert cfg["log_max_size"] to bytes. Assume its already in bytes
+    # if its > 1000000
+    if cfg["log_max_size"] < 1000000:
+        log_max_bytes = cfg["log_max_size"]*1024*1024
+    else:
+        log_max_bytes = cfg["log_max_size"]
+
     log_handler = logging.handlers.RotatingFileHandler(
-        cfg["log_file"], maxBytes=cfg["log_max_size"], backupCount=4,
+        cfg["log_file"], maxBytes=log_max_bytes, backupCount=4,
         # encoding='bz2')
     )
     formatter = logging.Formatter(


### PR DESCRIPTION
We talked about changing the the setting of `log_max_size` to megabytes instead of bytes a couple of months back (see: https://github.com/shawn-sterling/graphios/pull/74), completely forgot about it after that but anyways, here's a pull request for that. :)

And also removed some trailing whitespaces.