### PR TITLE
process_log: output hostname and servicedesc if we have problems pars…

### DIFF
--- a/graphios.py
+++ b/graphios.py
@@ -372,8 +372,9 @@ def process_log(file_name):
                     nobj.UOM = re.sub("[^a-zA-Z]+", "", u)
                     processed_objects.append(nobj)
                 except:
-                    log.critical("failed to parse label: '%s' part of perf"
-                                 "string '%s'" % (metric, nobj.PERFDATA))
+                    log.critical("failed to parse label '%s' for "
+                                 "host '%s' service '%s' perfdata '%s'"
+                        % (metric, nobj.HOSTNAME, nobj.SERVICEDESC, nobj.PERFDATA))
                     continue
     return processed_objects
 


### PR DESCRIPTION
Shawn: If acceptable, this includes hostname and servicedesc in one of the log messages inside of process_log(). I found this immensely helpful when troubleshooting some homegrown nagios plugin outputs.